### PR TITLE
fix(github): checkout syntax

### DIFF
--- a/.github/workflows/reusable-android-release.yaml
+++ b/.github/workflows/reusable-android-release.yaml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          branch: master
+          ref: master
+          fetch-depth: 0
 
       - name: Retrieve version
         id: versionName


### PR DESCRIPTION
for https://github.com/rees46/development/issues/2654

- версия релиза не успела за актуальной версией в мастере
- ранее была аналогичная ошибка в publish-workflow, фиксил аналогично