### PR TITLE
Feat/read replacements action

### DIFF
--- a/.github/actions/sync/read-replacements/action.yml
+++ b/.github/actions/sync/read-replacements/action.yml
@@ -1,0 +1,28 @@
+name: Read replacements
+description: checkout and read replacements by path
+
+inputs:
+  replacementsPath:
+    description: path to replacements.yml
+    default: .github/workflows/constants/replacements.yml
+    required: true
+
+outputs:
+  replacements:
+    description: replacements in compact json format in string
+    value: ${{ steps.getReplacementsStep.replacements }}
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Read replacements from file
+      shell: bash
+      id: getReplacementsStep
+      run: |
+        REPLACEMENTS=$(yq eval -o=json . ${{ inputs.replacementsPath }} | jq -c)
+        echo "Replacements: $REPLACEMENTS"
+
+        echo "replacements=$REPLACEMENTS" >> $GITHUB_OUTPUT

--- a/.github/actions/sync/read-replacements/action.yml
+++ b/.github/actions/sync/read-replacements/action.yml
@@ -5,12 +5,12 @@ inputs:
   replacementsPath:
     description: path to replacements.yml
     default: .github/workflows/constants/replacements.yml
-    required: true
+    required: false
 
 outputs:
   replacements:
     description: replacements in compact json format in string
-    value: ${{ steps.getReplacementsStep.replacements }}
+    value: ${{ steps.getReplacementsStep.outputs.replacements }}
 
 runs:
   using: composite

--- a/scripts/clean-directory/src/entrypoint.ts
+++ b/scripts/clean-directory/src/entrypoint.ts
@@ -1,33 +1,116 @@
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
+import { promisify } from "node:util";
+import childProcess from "node:child_process";
 
-import type { Config } from "./interfaces/index.js";
+const exec = promisify(childProcess.exec);
 
-function safeDelete(targetDir: string, config: Config) {
-  const absoluteTarget = path.resolve(targetDir);
-
-  const walkDir = (dir: string) => {
-    fs.readdirSync(dir).forEach((file) => {
-      const fullPath = path.join(dir, file);
-      const relativePath = path.relative(absoluteTarget, fullPath);
-
-      const shouldKeep =
-        config.ignore?.includes(relativePath) ||
-        relativePath.startsWith(".git/") ||
-        relativePath === ".git";
-
-      if (shouldKeep) return;
-
-      fs.rmSync(fullPath, { recursive: true, force: true });
-      console.info(`Delete: ${fullPath}`);
-    });
-  };
-
-  walkDir(absoluteTarget);
+interface Config {
+  ignore?: string[];
 }
 
-const [configString, targetDir] = process.argv.slice(2);
-const config = JSON.parse(configString);
-console.log("Starting delete process...");
-safeDelete(targetDir, config);
-console.log("Delete completed successfully!");
+async function safeDelete(targetDir: string, config: Config) {
+  const absoluteTarget = path.resolve(targetDir);
+
+  if (!fs.existsSync(absoluteTarget)) {
+    console.error(`Error: Target directory ${absoluteTarget} does not exist`);
+    process.exit(1);
+  }
+
+  const tmpDir = path.join(os.tmpdir(), `backup-${Date.now()}`);
+  fs.mkdirSync(tmpDir, { recursive: true });
+  console.log(`Created temp directory: ${tmpDir}`);
+
+  const normalizedIgnores = (config.ignore || []).map((ignorePath) =>
+    path.normalize(ignorePath).replace(/\\/g, "/"),
+  );
+
+  for (const ignorePath of normalizedIgnores) {
+    const sourcePath = path.join(absoluteTarget, ignorePath);
+
+    if (fs.existsSync(sourcePath)) {
+      const destPath = path.join(tmpDir, ignorePath);
+      const destDir = path.dirname(destPath);
+
+      fs.mkdirSync(destDir, { recursive: true });
+
+      try {
+        if (fs.lstatSync(sourcePath).isDirectory()) {
+          await exec(`cp -r "${sourcePath}" "${destPath}"`);
+        } else {
+          fs.copyFileSync(sourcePath, destPath);
+        }
+        console.log(`Copied to temp: ${sourcePath} → ${destPath}`);
+      } catch (error) {
+        console.error(`Error copying ${sourcePath}: ${error}`);
+      }
+    }
+  }
+
+  console.log("Deleting all files...");
+  try {
+    const files = fs.readdirSync(absoluteTarget);
+    for (const file of files) {
+      if (file === ".git") continue;
+
+      const fullPath = path.join(absoluteTarget, file);
+      try {
+        fs.rmSync(fullPath, { recursive: true, force: true });
+        console.log(`Deleted: ${fullPath}`);
+      } catch (error) {
+        console.error(`Error deleting ${fullPath}: ${error}`);
+      }
+    }
+  } catch (error) {
+    console.error(`Error cleaning directory: ${error}`);
+  }
+
+  console.log("Restoring files from temp...");
+  try {
+    const restoreFiles = fs.readdirSync(tmpDir);
+    for (const file of restoreFiles) {
+      const sourcePath = path.join(tmpDir, file);
+      const destPath = path.join(absoluteTarget, file);
+
+      try {
+        if (fs.lstatSync(sourcePath).isDirectory()) {
+          await exec(`cp -r "${sourcePath}" "${destPath}"`);
+        } else {
+          fs.copyFileSync(sourcePath, destPath);
+        }
+        console.log(`Restored: ${sourcePath} → ${destPath}`);
+      } catch (error) {
+        console.error(`Error restoring ${sourcePath}: ${error}`);
+      }
+    }
+  } catch (error) {
+    console.error(`Error restoring files: ${error}`);
+  }
+
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log(`Cleaned temp directory: ${tmpDir}`);
+  } catch (error) {
+    console.error(`Error cleaning temp directory: ${error}`);
+  }
+}
+
+if (process.argv.length < 3) {
+  console.error("Usage: node script.js <config_json> <target_dir>");
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    const [configString, targetDir] = process.argv.slice(2);
+    const config = JSON.parse(configString);
+
+    console.log("Starting cleanup process...");
+    await safeDelete(targetDir, config);
+    console.log("Cleanup completed successfully!");
+  } catch (error) {
+    console.error("Error:", error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
for https://github.com/rees46/development/issues/2781
latest-run: https://github.com/PersonaClick/demo-android/pull/31/files

- выношу чтение replacements-constant в экшен
- переписал clean-script. теперь выносит ignore-файлы в /tmp, далее чистит директорию, далее восстанавливает файлы из /tmp. в предыдущей версии не игнорировал вложенные файлы