### PR TITLE
refacor(github): workflow

### DIFF
--- a/.github/workflows/reusable-android-publish.yaml
+++ b/.github/workflows/reusable-android-publish.yaml
@@ -94,10 +94,6 @@ jobs:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY_FILE_AS_BASE64_STRING: ${{ secrets.SIGNING_KEY_FILE_AS_BASE64_STRING }}
 
-      - name: Debug gradle.properties
-        run: |
-          cat gradle.properties
-
       - name: Create staging repository
         uses: nexus-actions/create-nexus-staging-repo@990063f02160c633c168037b8b3e8585c76469fe
         id: createStagingRepoStep
@@ -106,10 +102,6 @@ jobs:
           password: ${{ secrets.SONATA_PASSWORD }}
           staging_profile_id: ${{ secrets.SONATA_STAGING_PROFILE_ID }}
           base_url: 'https://s01.oss.sonatype.org/service/local/'
-
-      - name: Debug repo id
-        run: |
-          echo "${{ steps.createStagingRepoStep.outputs.repository_id }}"
 
       - name: Grant execute permission to gradlew
         run: chmod +x gradlew

--- a/.github/workflows/reusable-android-publish.yaml
+++ b/.github/workflows/reusable-android-publish.yaml
@@ -74,7 +74,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          ref: master
           fetch-depth: 0
 
       - name: Prepare Android Action
@@ -94,6 +93,10 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY_FILE_AS_BASE64_STRING: ${{ secrets.SIGNING_KEY_FILE_AS_BASE64_STRING }}
+
+      - name: Debug gradle.properties
+        run: |
+          cat gradle.properties
 
       - name: Create staging repository
         uses: nexus-actions/create-nexus-staging-repo@990063f02160c633c168037b8b3e8585c76469fe


### PR DESCRIPTION
https://github.com/atls/kmp/issues/32

- почистил debug steps
- change checkout ref to current on publish workflow

proof:
- на моих глазах закрылся staging repository
- экшен отработал успешно - https://github.com/rees46/kmp/actions/runs/15588778444/job/43902028987
- думаю, что задержка публикации. ожидаю получить пакет 
  - https://mvnrepository.com/search?q=rees46
  - https://s01.oss.sonatype.org/#nexus-search;quick~com.rees46